### PR TITLE
fix(AutoPlay): Fixed issue with auto-play not working on /user/.

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -146,6 +146,7 @@ export class App extends Component {
   }
   
   private _handleUpdatePlayerConfig(player: Player, config: PlayerConfig): PlayerConfig {
+    player.setData(config.args);
     this._modules.forEach(m => {
       const instanceConfig = (m as any) as onPlayerConfig;
       const instanceData = (m as any) as onPlayerData;
@@ -156,16 +157,19 @@ export class App extends Component {
       if (typeof instanceData.onPlayerData === 'function') {
         config.args = instanceData.onPlayerData(player, config.args);
       }
+      player.setData(config.args);
     });
 
     return config;
   }
   
   private _handleUpdatePlayerData(player: Player, data: PlayerData): PlayerData {
+    player.setData(data);
     this._modules.forEach(m => {
       const instance = (m as any) as onPlayerData;
       if (typeof instance.onPlayerData === 'function') {
         data = instance.onPlayerData(player, data);
+        player.setData(data);
       }
     });
 

--- a/src/app/bootstrap.inject.ts
+++ b/src/app/bootstrap.inject.ts
@@ -122,10 +122,17 @@ const getPlayerData = function(player: any) {
 };
 
 /**
+ * Whether the auto-play patch has been applied.
+ */
+let appliedAutoPlayPatch = false;
+
+/**
  * Fixes the autoplay setting. Currently YouTube doesn't use the autoplay if the
  * player is `detailpage`, which we need on /watch. This patch will fix it.
  */
 const fixAutoplay = () => {
+  if (appliedAutoPlayPatch) return;
+  appliedAutoPlayPatch = true;
   let win = window as YTWindow;
   for (let key in win._yt_player) {
     if (win._yt_player.hasOwnProperty(key) && typeof win._yt_player[key] === "function") {

--- a/src/app/player/Player.ts
+++ b/src/app/player/Player.ts
@@ -1,13 +1,14 @@
 import { IPlayer } from './IPlayer';
 import { EventTarget } from '../../libs/events/EventTarget';
 import { ServicePort } from "../../libs/messaging/ServicePort";
-import { PlayerData } from '../youtube/PlayerConfig';
+import { PlayerData, PlayerType } from '../youtube/PlayerConfig';
 import { PlaybackQuality } from '../youtube/PlayerApi';
 
 export class Player extends EventTarget implements IPlayer {
   private _id: string;
   private _elementId: string;
   private _port: ServicePort;
+  private _data: PlayerData;
 
   /**
    * Whether YouTube has initialized the player yet.
@@ -35,6 +36,22 @@ export class Player extends EventTarget implements IPlayer {
 
   setLoaded(loaded: boolean) {
     return this._port.callSync("player#loaded", this._id, loaded);
+  }
+
+  setData(data: PlayerData): void {
+    this._data = data;
+  }
+
+  getData(data: PlayerData): PlayerData {
+    return this._data;
+  }
+
+  isDetailPage(): boolean {
+    return this._data.el === PlayerType.DETAIL_PAGE || !this._data.el;
+  }
+
+  isProfilePage(): boolean {
+    return this._data.el === PlayerType.PROFILE_PAGE;
   }
 
   getId(): string {

--- a/src/app/youtube/Player.ts
+++ b/src/app/youtube/Player.ts
@@ -100,10 +100,6 @@ export class Player extends Component {
       const api = this.getApi();
       let value = (api as any)[name](...args);
 
-      if (name === "destroy") {
-        this.dispose();
-      }
-
       return value;
     } else {
       return returnValue.value;
@@ -185,6 +181,7 @@ export class Player extends Component {
   getApi(): PlayerApi {
     if (!this._api) {
       let player = this._element as PlayerApiElement;
+      if (!player) throw new Error("Player (" + this.getId() + ") is not initialized.");
 
       // Determine whether the API interface is on the element.
       if (typeof player.getApiInterface !== "function") {

--- a/src/libs/messaging/ServicePort.ts
+++ b/src/libs/messaging/ServicePort.ts
@@ -177,6 +177,7 @@ export class ServicePort extends Component {
       delete this._serviceInstances[id];
 
       if (instance.returnError) {
+        console.error(instance.returnError);
         throw instance.returnError;
       } else {
         return instance.returnValue;
@@ -242,6 +243,7 @@ export class ServicePort extends Component {
         break;
       case ServiceType.CALL_RESPONSE_ERROR:
         this._handleCallResponseErrorMessage(detail as ServicePayloadError);
+        break;
       case ServiceType.DISPOSE:
         this._receivedDispose = true;
         this.dispose();
@@ -276,6 +278,7 @@ export class ServicePort extends Component {
             response.returnValue = returnValue;
             this._port.send(response);
           }, (err: Error) => {
+            console.error(err);
             let response = {} as ServicePayloadError;
             response.id = id;
             response.type = ServiceType.CALL_RESPONSE_ERROR;


### PR DESCRIPTION
Fixed issue with auto-play not working on /user/ and if going to the profile page twice.
Fixed issue with the detail page player not auto-playing even if auto-play is disabled by calling `player.play()`.
Fixed issue with auto-play patch being applied twice.
Fixed issue with an error caused the connection to be disposed of.
Fixed issue with calling destroy on the player would cause the registered player to get disposed of. Apparently a destroyed player can be reused (memory leak?).

Closes #52, #17