### PR TITLE
fix(autoplay): add hacky method to prevent player from auto-playing.

### DIFF
--- a/src/app/bootstrap.inject.ts
+++ b/src/app/bootstrap.inject.ts
@@ -179,34 +179,6 @@ const applyAutoPlayPatch = () => {
   }
 };
 
-/*const applyAutoPlayPatch = () => {
-  if (appliedAutoPlayPatch) return;
-  appliedAutoPlayPatch = true;
-
-  let value: any = undefined;
-  Object.defineProperty(Object.prototype, "experiments", {
-    get: function() {
-      const keys = Object.keys();
-
-      return value;
-    },
-    set: function(val: any) {
-      value = val;
-    }
-  })
-
-  for (let key in app) {
-    if (app.hasOwnProperty(key) && app[key] && typeof app[key].constructor === "function") {
-      let fn = app[key].constructor.toString();
-      let m = fn.match(/this\.([a-zA-Z0-9$_]{1,3})=[^;]+\.autoplay/);
-      if (m && m[1]) {
-        app[key][m[1]] = autoplay;
-        break;
-      }
-    }
-  }
-};*/
-
 const handlePlayerCreate = async (playerFactory: PlayerFactory, playerConfig: PlayerConfig, fn?: Function): Promise<any> => {
   if (servicePort.isDisposed()) {
     if (fn) {

--- a/src/modules/autoplay/index.ts
+++ b/src/modules/autoplay/index.ts
@@ -50,18 +50,9 @@ export class AutoPlayModule extends Module implements onPlayerCreated, onPlayerD
 
   onPlayerData(player: Player, data: PlayerData): PlayerData {
     const api = this.getApi();
-
-    // Make the YouTube player respect the autoplay variable.
-    data.suppress_autoplay_on_watch = false;
-
-    // Prevent the YouTube player from ignoring `suppress_autoplay_on_watch`.
-    const flagsParser = new FlagsParser(data.fflags);
-    flagsParser.setValue("html5_new_autoplay_redux", "false");
-    data.fflags = flagsParser.toString();
-
+    
     if (api.isEnabled() && player.isDetailPage()) {
       if (api.getMode() === AutoPlayMode.STOP) {
-        data.suppress_autoplay_on_watch = true;
         data.autoplay = "0";
       }
     } else if (api.isChannelEnabled() && player.isProfilePage()) {

--- a/src/modules/autoplay/settings.tsx
+++ b/src/modules/autoplay/settings.tsx
@@ -2,8 +2,7 @@ import { ISettingsReact } from "../../settings/ISettings";
 import { h } from 'preact';
 import { Checkbox } from '../../ui/checkbox';
 import { Select } from '../../ui/select';
-import { AutoPlayMode } from "./index";
-import { Api } from "./api";
+import { Api, AutoPlayMode } from "./api";
 import { AutoNavigationState } from "../../app/youtube/PlayerApi";
 
 export class Settings implements ISettingsReact {


### PR DESCRIPTION
YouTube removed the awesome feature that made it possible to tell the player to not auto-play a video on /watch. That required me to re-implement the hacky method I used before then.